### PR TITLE
Reduce LED brightness after boot up

### DIFF
--- a/debian/ev3dev-leds.service
+++ b/debian/ev3dev-leds.service
@@ -14,8 +14,8 @@ ExecStart=/bin/sh -c 'echo none > "/sys/class/leds/ev3:red:right/trigger";     \
                       echo none > "/sys/class/leds/ev3:green:left/trigger";    \
                       echo 0 > "/sys/class/leds/ev3:red:right/brightness";     \
                       echo 0 > "/sys/class/leds/ev3:red:left/brightness";      \
-                      echo 255 > "/sys/class/leds/ev3:green:right/brightness"; \
-                      echo 255 > "/sys/class/leds/ev3:green:left/brightness"'
+                      echo 4 > "/sys/class/leds/ev3:green:right/brightness"; \
+                      echo 0 > "/sys/class/leds/ev3:green:left/brightness"'
 ExecStop=/bin/sh -c 'echo none > "/sys/class/leds/ev3:red:right/trigger";   \
                      echo none > "/sys/class/leds/ev3:red:left/trigger";    \
                      echo none > "/sys/class/leds/ev3:green:right/trigger"; \


### PR DESCRIPTION
Based on feedback from this pull request (https://github.com/ev3dev/ev3dev-kernel/pull/6), making LED brightness lower post-boot, without affecting the behaviour at boot-time, or shutdown.
